### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/geoupdate.py
+++ b/geoupdate.py
@@ -37,7 +37,7 @@ def setup():
 
 
 def update(product_name, product):
-    download_url = 'https://geoip.maxmind.com/app/geoip_download?' \
+    download_url = 'https://download.maxmind.com/app/geoip_download?' \
                    'edition_id={0}&suffix={1}&' \
                    'license_key={2}'.format(product['id'],
                                             product['format'], LICENSE_KEY)


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)